### PR TITLE
fix error that occurs when no user name is present in stream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       -
         name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on: [push]
-
+ 
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     steps:
       -
         name: Checkout

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Arguments are:
 ```
     --host  default=0.0.0.0 (bind host - 0.0.0.0 to allow outside connections)
     --port default='9429' (bind port i.e. what prometheus scrapes)
-    --username (username for authentication, can be set via ENV Var TVH_USER')
+    --username (username for authentication, can be set via ENV Var TVH_USER)
     --password (password for authentication, can be set via ENV Var TVH_PASS)
-    --server (server url for tvheadend, can be set via ENV Var TVH_SERVER)
+    --server (server IP for tvheadend, can be set via ENV Var TVH_SERVER)
+    --serverport (server port for tvheadend, can be set via ENV Var TVH_PORT)
 ```
 
 <!-- Metrics Exporter -->

--- a/server.py
+++ b/server.py
@@ -285,7 +285,7 @@ class tvheadendCollector(object):
             for connection in connections:
                 hostname = connection['peer']
                 typename = connection['type']
-                if "name" in connection.keys():
+                if 'name' in connection.keys():
                     username = connection['user']
                 else:
                     username = ''
@@ -301,7 +301,7 @@ class tvheadendCollector(object):
                 title = subscription['title']
                 state = subscription['state']
                 hostname = subscription.get('hostname', '')
-                if username in subscription.keys():
+                if 'username' in subscription.keys():
                     username = subscription.get('username', '')
                 else:
                     username = ''

--- a/server.py
+++ b/server.py
@@ -285,7 +285,7 @@ class tvheadendCollector(object):
             for connection in connections:
                 hostname = connection['peer']
                 typename = connection['type']
-                if 'name' in connection.keys():
+                if 'user' in connection.keys():
                     username = connection['user']
                 else:
                     username = ''

--- a/server.py
+++ b/server.py
@@ -239,7 +239,10 @@ class tvheadendCollector(object):
             for service in services:
                 network_name = service['network']
                 mux_name = service['multiplex']
-                service_name = service['svcname']
+                if 'svcname' in service.keys():
+                    service_name = service['svcname']
+                else:
+                    service_name = ""
 
                 metrics['service_enabled'].add_metric(
                     [network_name, mux_name, service_name], int(service['enabled']))

--- a/server.py
+++ b/server.py
@@ -285,7 +285,10 @@ class tvheadendCollector(object):
             for connection in connections:
                 hostname = connection['peer']
                 typename = connection['type']
-                username = connection['user']
+                if "name" in connection.keys():
+                    username = connection['user']
+                else:
+                    username = ''
                 streaming = connection['streaming']
 
                 metrics['connection_streaming'].add_metric(
@@ -298,7 +301,10 @@ class tvheadendCollector(object):
                 title = subscription['title']
                 state = subscription['state']
                 hostname = subscription.get('hostname', '')
-                username = subscription.get('username', '')
+                if username in subscription.keys():
+                    username = subscription.get('username', '')
+                else:
+                    username = ''
                 client = subscription.get('client', '')
                 channel = subscription.get('channel', '')
                 service = subscription.get('service', '')


### PR DESCRIPTION
When streaming, the user name returned by the API is sometimes missing if no matching user is configured.
This pr is tested and fixes this error by returning an empty username string if the API does not return one.